### PR TITLE
Restructured project configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,9 +64,7 @@ $RECYCLE.BIN/
 *.lnk
 
 ### Project specific ###
-build*
 software/build-*
-software/remote/translations/.DS_Store
 
 # plugins
 plugins/*.so

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,83 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
 
-ir.pro.user
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk# Thumbnails
+._*
+### Linux ###
+*~
+.directory
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+### Project specific ###
+build*
+software/build-*
+software/remote/translations/.DS_Store
+
+# plugins
+plugins/*.so
+
+*.user
+*.user.*
+*.dylib
+*.o
+*.bak
+*.old
+*.log
+.qmake.stash
+# Makefile should always be generated with qmake
+Makefile

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,3 @@
+# only check in empty directory to be able to select it in Qt Creator for shallow builds
+*
+!.gitignore

--- a/ir.pro
+++ b/ir.pro
@@ -1,12 +1,22 @@
 TEMPLATE        = lib
 CONFIG         += plugin
 QT             += core quick
+
+include(../remote-software/qmake-target-platform.pri)
+include(../remote-software/qmake-destination-path.pri)
+
 HEADERS         = ir.h \
                   ../remote-software/sources/integrations/integration.h \
                   ../remote-software/sources/integrations/integrationinterface.h
 SOURCES         = ir.cpp
 TARGET          = ir
-DESTDIR         = ../remote-software/plugins
+
+# Configure destination path by "Operating System/Compiler/Processor Architecture/Build Configuration"
+DESTDIR = $$PWD/../binaries/$$DESTINATION_PATH/plugins
+OBJECTS_DIR = $$PWD/build/$$DESTINATION_PATH/obj
+MOC_DIR = $$PWD/build/$$DESTINATION_PATH/moc
+RCC_DIR = $$PWD/build/$$DESTINATION_PATH/qrc
+UI_DIR = $$PWD/build/$$DESTINATION_PATH/ui
 
 # install
 unix {


### PR DESCRIPTION
Build output changes:
- Separate build and binary folders for different compilers and architectures:
     `<Operating System>/<Compiler>/<Processor Architecture>/<Build Configuration>`
- Temporary build artefacts are generated in `./build` sub-folder (shadow build).
  - Automatically used for command line `qmake && make` build.
  - Directory can also be used for Qt Creator to get rid of the annoying default `build-ir....` directory in the parent folder of the project.
    This can be changed in Qt Creator during project import or in build settings.

- Compiled plugin binary is stored into common parent folder `../binaries` alongside the remote-software app within the plugins folder. (Old destination: remote-software/plugins).

This is part of https://github.com/YIO-Remote/remote-software/pull/327